### PR TITLE
cleanup and expansion of tutorial pages

### DIFF
--- a/docs/codes/DOL_codes.md
+++ b/docs/codes/DOL_codes.md
@@ -46,7 +46,12 @@ Change the value at any of the offsets to ```0E 52``` to reverse the ghosts' spa
 
 ##**Beta Spinning Coins by Ralf (Upside Down Bug Fix by 0wen)**
 
-At offset ```0xD50```, paste/write ```3C608000C0033D6CC03D0024EC21002AD03D0024A87C00A64815427C41700000```
+At offset ```0xD50```,
+
+paste/write ```3C608000C0033D6CC03D0024EC21002AD03D0024A87C00A64815427C41700000```
+
 At offset ```0x15402C```, paste/write ```3800BC00B01E005E```
+
 At offset ```0x154D40```, paste/write ```4BEABD70```
+
 (Credit: weirdboo, 0wen)

--- a/docs/research.md
+++ b/docs/research.md
@@ -3,6 +3,10 @@ hide:
   - toc
 ---
 
+<figure markdown> 
+# Research
+</figure>
+
 !!! warn "Note"
 	This page should be considered as a work in progress. Generally, this should help with understanding how various parts of the game work, and that understanding may not always be 100% correct.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -3,5 +3,9 @@ hide:
   - toc
 ---
 
+<figure markdown> 
+# Tools
+</figure>
+
 Below is a list of Luigi's Mansion modding tools and related programs. 
 If you are unsure of what to start with, [check out the tutorials.](https://www.lbmwiki.net/tutorials)

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,6 +1,7 @@
 ---
 hide:
   - toc
+  - navigation
 ---
 <figure markdown> 
 # Tutorials 
@@ -20,22 +21,22 @@ Below is a list of tutorials for modding and related software.
     7. [TBD](tutorials/07_TBD.md)
     8. [TBD](tutorials/08_TBD.md)           
 
-=== "Specific Tutorials"
-    ##Tutorials for hacking specific things
-
-	1. [How to Change Ghost Colors](tutorials/09_Ghost_Color.md)
-    2. How to Create Custom Furniture
-    3. How to Change the GameID
-    4. How to Edit Textures for Luigi, Poltergust, and Mario
-    5. How to Make Fire Elemental Ghosts Sparkle
-    6. How to Restore the Beta Flashlight
-    7. How to Restore the Unused GameBoy Horror Camera
-
 === "General Tutorials"
     ##General Hacking Tutorials
 
-    1. Editing Models
-    2. Editing Sounds
-    3. Custom Events
-    4. Particle Effects
-    5. Texture Editing
+    1. [Editing Textures](tutorials/09_Editing_textures.md)
+    2. [Editing Models](tutorials/10_Editing_models.md)
+    3. [Editing Sounds](tutorials/11_Editing_sounds.md)
+    4. [Particle Effects](tutorials/12_particals.md)
+    5. [Custom Events](tutorials/13_Custom_events.md)
+
+=== "Specific Tutorials"
+    ##Tutorials for hacking specific things
+
+	1. [How to Change Ghost Colors](tutorials/14_Ghost_Color.md)
+    2. [How to Create Custom Furniture](tutorials/15_Custom_furniture.md)
+    3. [How to Change the GameID](tutorials/16_GameID.md)
+    4. [How to Edit Textures for Luigi, Poltergust, and Mario](tutorials/17_LMP_textures.md)
+    5. [How to Make Fire Elemental Ghosts Sparkle](tutorials/18_Fire_ghost_sparkle.md)
+    6. [How to Restore the Beta Flashlight](tutorials/19_Beta_flashlight.md)
+    7. [How to Restore the Unused GameBoy Horror Camera](tutorials/20_GBH_camera.md)

--- a/docs/tutorials/01_Patches.md
+++ b/docs/tutorials/01_Patches.md
@@ -3,6 +3,9 @@
 For legal reasons, both playing and sharing mods requires the use of a patch system.
 Either way, you need to make sure that you have dumped (or acquired) a known-good dump of Luigi's Mansion, which can be done using [Dolphin Emulator.](https://www.lbmwiki.net/tools/dolphin/)
 
+!!! warning "Warning"
+	If you intend on modding the PAL version, we highly recommend using PAL 1.01; all of our hosted PAL hacks are based on this version.
+
 === "Applying Patches"
 	
 	Make sure that Dolphin knows where your game files are. At the top of the window, choose Options → Configuration → Paths and add the location of your ISO file(s) to this section.
@@ -14,11 +17,8 @@ Either way, you need to make sure that you have dumped (or acquired) a known-goo
 			NTSC-U 1.00 - 6e3d9ae0ed2fbd2f77fa1ca09a60c494
 			NTSC-J 1.00 - 83839f063e42f04147157382dcb019b2
 			PAL    1.01 - 109274d9078b5aecf3bfa9af1d10688c
+
 		
-	
-	!!! warning "Warning"
-		If you are using a PAL rom, make sure it is the PAL 1.01 revision, as all hosted PAL mods use it.
-	
 	After that, applying the patch is handled by xdelta UI, as shown below:
 	
 	![ ](img_tutorials/xdelta_apply.png){ height='400" }
@@ -32,8 +32,6 @@ Either way, you need to make sure that you have dumped (or acquired) a known-goo
 	![ ](img_tutorials/xdelta_create.png){ height='400" }
 	
 	To create a patch, select the vanilla, unaltered game ISO, your modded ISO, and then save the file. It will output as a .xdelta file.
-	
-	!!! warning "Warning"
-		If you intend on modding the PAL version, we highly recommend using PAL 1.01; all of our hosted PAL hacks are based on this version.
+
 		
-###[Next :material-arrow-right-bold-box:](02_Recommended_Tools.md) { align=center }
+#[:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](02_Recommended_Tools.md) { align=center }

--- a/docs/tutorials/02_Recommended_Tools.md
+++ b/docs/tutorials/02_Recommended_Tools.md
@@ -3,9 +3,9 @@
 To get started, there are a few tools we suggest getting your hands on. Each hyperlink below will lead you to a page with some more information about each tool/program, as well as where to download it.
 
 ##Bare Minimum
-- [Dolphin Emulator](https://www.lbmwiki.net/tools/Dolphin)
-- [XDelta UI Patcher](https://www.lbmwiki.net/tools/XDeltaUI)
-- [GCRebuilder](https://www.lbmwiki.net/tools/GCR)
+- [Dolphin Emulator](https://www.lbmwiki.net/tool_pages/Dolphin)
+- [XDelta UI Patcher](https://www.lbmwiki.net/tool_pages/XDeltaUI)
+- [GCRebuilder](https://www.lbmwiki.net/tool_pages/GCR)
 
 ##More Advanced Modding
 - RARCTools
@@ -17,4 +17,4 @@ To get started, there are a few tools we suggest getting your hands on. Each hyp
 
 For a full list of tools, [check out the tools index page.](https://www.lbmwiki.net/tools)
 
-######[:material-arrow-left-bold-box: Back](01_Patches.md) | [Next :material-arrow-right-bold-box:](03_Root_Extraction.md) { align=center }
+#[:material-arrow-left-bold-box: Back](01_Patches.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](03_Root_Extraction.md) { align=center }

--- a/docs/tutorials/03_Root_Extraction.md
+++ b/docs/tutorials/03_Root_Extraction.md
@@ -19,4 +19,4 @@ After that, navigate to Root → Save to convert those files back into a disc im
 
 Then you're ready to run your hack in Dolphin, or on actual hardware, like via Nintendont or Swiss.
 
-###[:material-arrow-left-bold-box: Back](02_Recommended_Tools.md) | [Next :material-arrow-right-bold-box:](04_Dolphin_Setup.md) { align=center }
+#[:material-arrow-left-bold-box: Back](02_Recommended_Tools.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](04_Dolphin_Setup.md) { align=center }

--- a/docs/tutorials/04_Dolphin_Setup.md
+++ b/docs/tutorials/04_Dolphin_Setup.md
@@ -3,4 +3,4 @@
 !!! note "This page is under construction!"
 	Page content is coming soon!
 
-###[:material-arrow-left-bold-box: Back](03_Root_Extraction.md) | [Next :material-arrow-right-bold-box:](05_SZP_Files.md) { align=center }
+#[:material-arrow-left-bold-box: Back](03_Root_Extraction.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](05_SZP_Files.md) { align=center }

--- a/docs/tutorials/05_SZP_Files.md
+++ b/docs/tutorials/05_SZP_Files.md
@@ -3,4 +3,4 @@
 !!! note "This page is under construction!"
 	Page content is coming soon!
 
-###[:material-arrow-left-bold-box: Back](04_Dolphin_Setup.md) | [Next :material-arrow-right-bold-box:](06_Using_HxD.md) { align=center }
+#[:material-arrow-left-bold-box: Back](04_Dolphin_Setup.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](06_Using_HxD.md) { align=center }

--- a/docs/tutorials/06_Using_HxD.md
+++ b/docs/tutorials/06_Using_HxD.md
@@ -3,4 +3,4 @@
 !!! note "This page is under construction!"
 	Page content is coming soon!
 
-###[:material-arrow-left-bold-box: Back](05_SZP_Files.md) | [Next :material-arrow-right-bold-box:](07_TBD.md) { align=center }
+#[:material-arrow-left-bold-box: Back](05_SZP_Files.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](07_TBD.md) { align=center }

--- a/docs/tutorials/07_TBD.md
+++ b/docs/tutorials/07_TBD.md
@@ -3,4 +3,4 @@
 !!! note "This page is under construction!"
 	Page content is coming soon!
 
-###[:material-arrow-left-bold-box: Back](06_TBD.md) | [Next :material-arrow-right-bold-box:](08_TBD.md) { align=center }
+#[:material-arrow-left-bold-box: Back](06_Using_HxD.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](08_TBD.md) { align=center }

--- a/docs/tutorials/08_TBD.md
+++ b/docs/tutorials/08_TBD.md
@@ -3,4 +3,4 @@
 !!! note "This page is under construction!"
 	Page content is coming soon!
 
-###[:material-arrow-left-bold-box: Back](07_TBD.md) | [Next :material-arrow-right-bold-box:](09_TBD.md) { align=center }
+#[:material-arrow-left-bold-box: Back](07_TBD.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](09_Editing_textures.md) { align=center }

--- a/docs/tutorials/09_Editing_textures.md
+++ b/docs/tutorials/09_Editing_textures.md
@@ -1,0 +1,6 @@
+#09 - Editing textures
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](08_TBD.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](10_Editing_models.md) { align=center }

--- a/docs/tutorials/10_Editing_models.md
+++ b/docs/tutorials/10_Editing_models.md
@@ -1,0 +1,6 @@
+#10 - Editing models
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](09_Editing_textures.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](11_Editing_sounds.md) { align=center }

--- a/docs/tutorials/11_Editing_sounds.md
+++ b/docs/tutorials/11_Editing_sounds.md
@@ -1,0 +1,6 @@
+#11 - Editing sounds
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](10_Editing_models.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](12_particals.md) { align=center }

--- a/docs/tutorials/12_particals.md
+++ b/docs/tutorials/12_particals.md
@@ -1,0 +1,6 @@
+#12 - Particle effects
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](11_Editing_sounds.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](13_Custom_events.md) { align=center }

--- a/docs/tutorials/13_Custom_events.md
+++ b/docs/tutorials/13_Custom_events.md
@@ -1,0 +1,6 @@
+#13 - Custom events
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](12_particals.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](14_Ghost_Color.md) { align=center }

--- a/docs/tutorials/14_Ghost_Color.md
+++ b/docs/tutorials/14_Ghost_Color.md
@@ -1,4 +1,4 @@
-#Changing Ghost Color
+#14 - Changing Ghost Color
 
 To change a ghost's color you must modify both the PRM, and the textures of the model.
 
@@ -40,4 +40,4 @@ With both the PRM and texture changed, the ghost's new color will look complete!
 !!! warning "Warning"
 		Some ghost models use multiple or duplicate body textures. If your texture edit doesn't appear, make sure you've edited the correct texture.
 
-###[Next :material-arrow-right-bold-box:](02_Recommended_Tools.md) { align=center }
+#[:material-arrow-left-bold-box: Back](13_Custom_events.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](15_Custom_furniture.md) { align=center }

--- a/docs/tutorials/15_Custom_furniture.md
+++ b/docs/tutorials/15_Custom_furniture.md
@@ -1,0 +1,6 @@
+#15 - Custom furniture
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](14_Ghost_Color.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](16_GameID.md) { align=center }

--- a/docs/tutorials/16_GameID.md
+++ b/docs/tutorials/16_GameID.md
@@ -1,0 +1,6 @@
+#16 - Changing the game ID
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](15_Custom_furniture.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](17_LMP_textures.md) { align=center }

--- a/docs/tutorials/17_LMP_textures.md
+++ b/docs/tutorials/17_LMP_textures.md
@@ -1,0 +1,6 @@
+#17 - Editing Mario, Luigi and the Poltergust's textures
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](16_GameID.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](18_Fire_ghost_sparkle.md) { align=center }

--- a/docs/tutorials/18_Fire_ghost_sparkle.md
+++ b/docs/tutorials/18_Fire_ghost_sparkle.md
@@ -1,0 +1,6 @@
+#18 - Making fire elementals sparkle
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](17_LMP_textures.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](19_Beta_flashlight.md) { align=center }

--- a/docs/tutorials/19_Beta_flashlight.md
+++ b/docs/tutorials/19_Beta_flashlight.md
@@ -1,0 +1,6 @@
+#19 - Restoring the beta flashlight
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](18_Fire_ghost_sparkle.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) | [Next :material-arrow-right-bold-box:](20_GBH_camera.md) { align=center }

--- a/docs/tutorials/20_GBH_camera.md
+++ b/docs/tutorials/20_GBH_camera.md
@@ -1,0 +1,6 @@
+#20 - Restoring the GBH camera
+
+!!! note "This page is under construction!"
+	Page content is coming soon!
+
+#[:material-arrow-left-bold-box: Back](19_Beta_flashlight.md) | [:material-hammer-screwdriver: Home](https://www.lbmwiki.net/tutorials) <!-- | [Next :material-arrow-right-bold-box:](09_TBD.md)--> { align=center }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,19 +3,19 @@ nav:
   - Home:
     - Home: index.md
   - Documentation:
-    - Main: documentation.md
+    - Main page: documentation.md
     - Events: documentation/Events.md
     - JMP Tables: documentation/JMP.md
     - Flags: documentation/Flags.md
     - Locations & Doors: documentation/Maps_Rooms_Doors.md
     - Parameter files: documentation/Parameters.md  
   - Tutorials:
-    - Main: tutorials.md
+    - Tutorials: tutorials.md
   - Research:
-    - Main: research.md
+    - Main page: research.md
     - File formats: research/file_formats.md
   - Tools: 
-    - Main: tools.md
+    - Main page: tools.md
     - General software: tools/general_software.md
     - file conversion tools: tools/convert_tools.md
     - editing tools: tools/edit_tools.md
@@ -23,6 +23,7 @@ nav:
     - RAM: codes/RAM_codes.md
     - DOL: codes/DOL_codes.md
     - AR codes: codes/AR_codes.md
+
 theme:
   name: material
   logo: assets/favicon.png


### PR DESCRIPTION
added a new home button to the buttons at the bottom of every tutorial page, 
added template files for the rest of the tutorials listed on the index page, 
simplified the patching tutorial slightly, 
made tutorial page buttons larger, 
removed back | next appearing in the table of contents
changed "Main" to "Main page"
fixed broken links

also hi geeky lolmayo